### PR TITLE
Replace manual table of contents with kramdown-generated TOC

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -18,26 +18,8 @@ title: "Foundations for Open Scholarship Strategy Development"
 
 ### Table of Contents
 
-* [Purpose of this Document](#Purpose)
-* [Strategy](#Strategy)
-  * [Short-term strategy, <2 years](#Short)
-  * [Mid-term strategy, 2-5 years](#Middle)
-  * [Long-term strategy, >5 years](#Long)
-* [What is Open Scholarship?](#What_is)
-* [State of the Movement](#State)
-* [Top Strategic Priorities for Open Scholarship](#Priorities)
-  * [Democratization](#Democratization)
-  * [Pragmatism and transparency](#Pragmatism)
-  * [Infrastructure](#Infrastructure)
-  * [Public good](#Public)
-  * [Measurement](#Measurement)
-  * [Community and inclusion](#Community)
-* [Movement Strengths](#Strengths)
-* [Movement Challenges](#Challenges)
-  * [External conditions](#External)
-  * [Internal conditions](#Internal)
-* [Opportunities](#Opportunities)
-* [Threats](#Threats)
+1. This will be replaced by an actual TOC by kramdown
+{:toc}
 
 The first draft (Version 1.2) of this document has now been [**PUBLISHED**](https://zenodo.org/record/1323437#.W163StL7RPY). 
 


### PR DESCRIPTION
This pull request doesn't do much, but I'm having a hard time wrapping my head around the organization of the site. If I got it right, this will simply replace the current TOC with an autogenerated TOC that is then easy to keep updated.

I'm assuming that there is a build server that turns the rmarkdown to markdown for github pages that serves the actual page. If not, I'm not sure I understand how you get from rmarkdown to the site. As far as I could find out, Jekyll can't build rmarkdown and there where no configs in the repo. I'm also not sure why the index is in rmarkdown, since there is no r in it.

Feel free to correct my misconceptions and point me in the right direction!