### PR TITLE
Simple styling for TOC

### DIFF
--- a/_sass/basically-basic/_toc.scss
+++ b/_sass/basically-basic/_toc.scss
@@ -1,0 +1,26 @@
+/* ==========================================================================
+   TOC
+   ========================================================================== */
+
+#markdown-toc {
+  width: 100%;
+  max-width: $sidebar-width;
+  height: 100%;
+  font-size: $min-font-size;
+  list-style-type: none;
+
+  @include breakpoint($large) {
+    max-width: (1.2 * $sidebar-width);
+  }
+
+
+  li {
+    a {
+      color: $base-color;
+
+      &:hover {
+        color: $accent-color;
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added simple styling for TOC. This file is missing from the current build, which may cause build errors.

I could get it to float on the right side of the screen, but there were too many problems to commit that version yet. I'm not sure what the problem was, so I'll have to look into it later.